### PR TITLE
fix(quiesce-hangs): Fixes issue that hangs on term

### DIFF
--- a/kubernetes/bluemix/multi-tenant/deploy-multitenant.json
+++ b/kubernetes/bluemix/multi-tenant/deploy-multitenant.json
@@ -53,13 +53,13 @@
                         }
                     },
                     "command": ["/bin/sh", "-c"],
-                    "args": ["export SDP_ADDRESS=$(hostname -i); (/vgw-media-relay/bin/rtp-relay) | (node lib/RotatingLoggerStream.js)"],
+                    "args": ["export SDP_ADDRESS=$(hostname -i); exec /vgw-media-relay/bin/media-relay"],
                     "env": [{
                         "name": "ENABLE_RECORDING",
                         "value": "false"
                     }, {
                         "name": "RTP_UDP_PORT_RANGE",
-                        "value": "16384-16394"
+                        "value": "16384-16584"
                     }, {
                         "name": "CLUSTER_WORKERS",
                         "value": "0"
@@ -111,7 +111,7 @@
                          "value": "9443"
                     }, {
                          "name": "HTTP_HOST",
-                         "value": "127.0.0.1"                        
+                         "value": "127.0.0.1"
                     }, {
                         "name": "ENABLE_AUDIT_MESSAGES",
                         "value": "true"

--- a/kubernetes/bluemix/single-tenant/deploy.json
+++ b/kubernetes/bluemix/single-tenant/deploy.json
@@ -44,13 +44,13 @@
                         }
                     },
                     "command": ["/bin/sh", "-c"],
-                    "args": ["export SDP_ADDRESS=$(hostname -i); (/vgw-media-relay/bin/rtp-relay) | (node lib/RotatingLoggerStream.js)"],
+                    "args": ["export SDP_ADDRESS=$(hostname -i); exec /vgw-media-relay/bin/media-relay"],
                     "env": [{
                         "name": "ENABLE_RECORDING",
                         "value": "false"
                     }, {
                         "name": "RTP_UDP_PORT_RANGE",
-                        "value": "16384-16394"
+                        "value": "16384-16584"
                     }, {
                         "name": "CLUSTER_WORKERS",
                         "value": "0"
@@ -133,7 +133,7 @@
                          "value": "9443"
                     }, {
                          "name": "HTTP_HOST",
-                         "value": "127.0.0.1"                        
+                         "value": "127.0.0.1"
                     }, {
                         "name": "WATSON_CONVERSATION_WORKSPACE_ID",
                         "value": ""

--- a/stt-adapter/kubernetes/bluemix/single-tenant/deploy.json
+++ b/stt-adapter/kubernetes/bluemix/single-tenant/deploy.json
@@ -94,7 +94,7 @@
     			    }
   			},
 			"command": ["/bin/sh", "-c"],
-			"args": ["export SDP_ADDRESS=$(hostname -i); (/vgw-media-relay/bin/rtp-relay) | (node lib/RotatingLoggerStream.js)"],
+      "args": ["export SDP_ADDRESS=$(hostname -i); exec /vgw-media-relay/bin/media-relay"],
 			"env": [{
 			  "name": "ENABLE_RECORDING",
 			  "value": "false"


### PR DESCRIPTION
Due to the change for quiescing calls, in general the Media Relay was
not trapping kill signals. This corrects the behavior so the deployment
gets cleaned up correctly on deletion.

Closes #127