### PR TITLE
147-Adding IBM IAM support for creating Watson Assistant.

### DIFF
--- a/soe/node/SOE_VGW_WCS/README.md
+++ b/soe/node/SOE_VGW_WCS/README.md
@@ -26,6 +26,26 @@ This application requires one service instance of IBM Voice Gateway.
 IBM Voice Gateway in turn requires one Watson Assistant (former Watson Conversation), one Watson Speech To Text, and one Watson Text To Speech Service instance.
 Combined, the above four services has to be running to demonstrate/run this application.
 
+
+## Authentication Mechanism
+
+This application is capable of validating user by IBM IAM and the classic mechanism of using userName and password. 
+Manifest.yml guides user to choose the user identifcation mechanism.
+Set "USING_IAM: true" for using IAM way of Authentication. Set the variable to false for using userName and password
+
+USING_IAM: true (Set following variables)
+
+1. WATSON_CONVERSATION_APIKEY
+2. WATSON_WORKSPACE_ID
+3. WATSON_ASSISTANT_URL
+4. WATSON_ASSITANT_RELEASE_VERSION
+
+USING_IAM: false (Set following variables) 
+
+1. wcs_username 
+2. wcs_password
+3. wcs_workspace
+
 ## Parameters
 
 Please set the following parameters in the manifest.yml file.
@@ -37,6 +57,11 @@ Please set the following parameters in the manifest.yml file.
 5) receiver_email_address: Some email address, comma separated multiple email addresses permitted
 6) sender_email_address: Some email address, only one permitted
 7) sender_email_password: Password for the sender email address
+8) USING_IAM : This Environment variable identifies if IBM IAM us used. 
+9) WATSON_CONVERSATION_APIKEY: Watson Assistant API key. 
+10) WATSON_WORKSPACE_ID: Watson Assitant workspace ID
+11) WATSON_ASSISTANT_URL: Watson Assistant URL based on hosting location, Eg Dallas has https://gateway.watsonplatform.net/assistant/api>
+12) WATSON_ASSITANT_RELEASE_VERSION: Typically the date of release of Watson Assistant which you are trying to use. 
 
 These parameters would get uploaded as environment variables for the bluemix application.
 The parameters can also be modified at the runtime from the environment variables configuration page of the bluemix application.

--- a/soe/node/SOE_VGW_WCS/app.js
+++ b/soe/node/SOE_VGW_WCS/app.js
@@ -12,12 +12,32 @@ if (process === null || process.env === null){
 	console.log("Not being able to read environment variables.");
 }
 
-var conversation = watson.conversation({
-	username: process.env.wcs_username,
-	password: process.env.wcs_password,
-	version: 'v1',
-	version_date: '2017-05-26'
-});
+//Watson Assistant will be constructed to this variable.  
+var conversation;
+
+
+//Environment variable is used to idenify usage of IBM IAM and Watson assistant is constructed.
+//Change "process.env.USING_IAM" to false in manifest.yml to use userID and password way of Watson Assistant construction.  
+//Current block is backward compatible for all the implementation using userID and password.
+
+if (process.env.USING_IAM) {
+
+	conversation = new watson.AssistantV1({
+	  iam_apikey: process.env.WATSON_CONVERSATION_APIKEY,
+	  version: process.env.WATSON_ASSITANT_RELEASE_VERSION,
+	  url: process.env.WATSON_ASSISTANT_URL
+	});
+
+}else{	
+
+	conversation = watson.conversation({
+		username: process.env.wcs_username,
+		password: process.env.wcs_password,
+		version: 'v1',
+		version_date: '2017-05-26'
+   	});
+}
+
 
 var showAllLogs = (process.env.show_all_logs === 'true');
 var receiverEmailAddress = process.env.receiver_email_address;
@@ -100,7 +120,7 @@ function commonGetPostCall(request, response) {
 		console.log(JSON.stringify(reqBody.input.text, null, 2));
 	}
 
-	reqBody.workspace_id = process.env.wcs_workspace;
+	reqBody.workspace_id = (process.env.USING_IAM)? process.env.WATSON_WORKSPACE_ID: process.env.wcs_workspace;
 
 	conversation.message(reqBody, function(err, response2) {
 		if (err) {

--- a/soe/node/SOE_VGW_WCS/manifest.yml
+++ b/soe/node/SOE_VGW_WCS/manifest.yml
@@ -12,4 +12,13 @@ applications:
     receiver_email_address: yourstruly@gmail.com
     sender_email_address: abc@gmail.com
     sender_email_password: xyz123
-    
+    USING_IAM : true
+    WATSON_CONVERSATION_APIKEY: <Your API Key>
+    WATSON_CONVERSATION_TOKEN_SERVICE_PROVIDER_URL: https://iam.bluemix.net/identity/token
+    WATSON_WORKSPACE_ID: <YOUR WATSON ASSISTANT WORKSPACE ID>
+    WATSON_ASSISTANT_URL: <Watson assistant URL based on hosting location, Eg Dallas has https://gateway.watsonplatform.net/assistant/api>
+    WATSON_ASSITANT_RELEASE_VERSION: <version of whatson assitant you are trying to use.>
+
+
+
+


### PR DESCRIPTION
Team, I have added an IAM way of authentication while creating Watson Assistant for Node/SOE-VGW-WCS. This code is backwards compatible with using username and password. 

Corresponding README.md also updated to show the way of doing it. 