### PR TITLE
fix: Removes IAM Endpoint definition

### DIFF
--- a/docker/docker-compose-agent-assist.yml
+++ b/docker/docker-compose-agent-assist.yml
@@ -11,15 +11,17 @@ services:
       - MEDIA_RELAY_HOST=media.relay:8080
       - SIP_HOST=${EXTERNAL_IP}
 
+
+      - WATSON_CONVERSATION_URL=
+
       # Configure either an SOE or reporting interface to receive the transcriptions (or both)
       # SOE
+      #If your account is associated with an apikey uncomment WATSON_CONVERSATION_APIKEY and fill the apikey accordingly
+      #- WATSON_CONVERSATION_APIKEY=
+
       #If your account is associated with a username and password uncomment WATSON_CONVERSATION_USERNAME and WATSON_CONVERSATION_PASSWORD
       #- WATSON_CONVERSATION_USERNAME=
       #- WATSON_CONVERSATION_PASSWORD=
-      #If your account is associated with an apikey uncomment WATSON_CONVERSATION_APIKEY and WATSON_CONVERSATION_TOKEN_SERVICE_PROVIDER_URL and fill apikey accordingly
-      #- WATSON_CONVERSATION_APIKEY=
-      #- WATSON_CONVERSATION_TOKEN_SERVICE_PROVIDER_URL=https://iam.bluemix.net/identity/token
-      - WATSON_CONVERSATION_URL=
        
       # Reporting
       - REPORTING_URL=
@@ -38,12 +40,13 @@ services:
       - MEDIA_RELAY_LOG_LEVEL=DEBUG
       - MEDIA_RELAY_WS_PORT=8080
 
-      # Creds for Bluemix STT
+      - WATSON_STT_URL=
+
+      # Credentials for IBM Cloud Speech-To-Text Service
+      #If your account is associated with an apikey uncomment WATSON_STT_APIKEY and fill the apikey accordingly
+      #- WATSON_STT_APIKEY=
+
       #If your account is associated with a username and password uncomment WATSON_STT_USERNAME and WATSON_STT_PASSWORD and fill accordingly
       #- WATSON_STT_USERNAME=
       #- WATSON_STT_PASSWORD=
-      #If your account is associated with an apikey uncomment WATSON_STT_APIKEY and WATSON_STT_TOKEN_SERVICE_PROVIDER_URL and fill apikey accordingly
-      #- WATSON_STT_APIKEY=
-      #- WATSON_STT_TOKEN_SERVICE_PROVIDER_URL=https://iam.bluemix.net/identity/token
-      - WATSON_STT_URL=
 

--- a/docker/docker-compose-self-service.yml
+++ b/docker/docker-compose-self-service.yml
@@ -11,15 +11,15 @@ services:
       - MEDIA_RELAY_HOST=media.relay:8080
       - SIP_HOST=${EXTERNAL_IP}
 
-      # Uncomment and specify when the Conversation API is used
+      - WATSON_CONVERSATION_URL=
       - WATSON_CONVERSATION_WORKSPACE_ID=
+
+      # API Key for IBM Cloud Watson Assistant Service
+      - WATSON_CONVERSATION_APIKEY=
+
       #If your account is associated with a username and password uncomment WATSON_CONVERSATION_USERNAME and WATSON_CONVERSATION_PASSWORD and fill out accordingly
       #- WATSON_CONVERSATION_USERNAME=
       #- WATSON_CONVERSATION_PASSWORD=
-      #If your account is associated with an apikey uncomment WATSON_CONVERSATION_APIKEY and WATSON_CONVERSATION_TOKEN_SERVICE_PROVIDER_URL and fill apikey accordingly
-      #- WATSON_CONVERSATION_APIKEY=
-      #- WATSON_CONVERSATION_TOKEN_SERVICE_PROVIDER_URL=https://iam.bluemix.net/identity/token
-      - WATSON_CONVERSATION_URL=
 
       # Logging related variables
       - ENABLE_TRANSCRIPTION_AUDIT_MESSAGES=true
@@ -36,23 +36,23 @@ services:
       - MEDIA_RELAY_LOG_LEVEL=DEBUG
       - MEDIA_RELAY_WS_PORT=8080
 
-      # Creds for Bluemix STT
-      #If your account is associated with a username and password uncomment WATSON_STT_USERNAME and WATSON_STT_PASSWORD and fill out accordingly
+      - WATSON_STT_URL=
+      # API Key for IBM Cloud Speech-To-Text Service
+      - WATSON_STT_APIKEY=
+
+      #If your account is associated with a username and password uncomment WATSON_STT_USERNAME and WATSON_STT_PASSWORD and fill accordingly
       #- WATSON_STT_USERNAME=
       #- WATSON_STT_PASSWORD=
-      #If your account is associated with an apikey uncomment WATSON_STT_APIKEY and WATSON_STT_TOKEN_SERVICE_PROVIDER_URL and fill apikey accordingly
-      #- WATSON_STT_APIKEY=
-      #- WATSON_STT_TOKEN_SERVICE_PROVIDER_URL=https://iam.bluemix.net/identity/token
-      - WATSON_STT_URL=
 
-      # Creds for Bluemix TTS
-      #If your account is associated with a username and password uncomment WATSON_TTS_USERNAME and WATSON_TTS_PASSWORD and fill out accordingly
+
+
+      - WATSON_TTS_URL=
+      # API Key for IBM Cloud Text-To-Speech Service
+      - WATSON_TTS_APIKEY=
+
+      #If your account is associated with a username and password uncomment WATSON_TTS_USERNAME and WATSON_TTS_PASSWORD and fill accordingly
       #- WATSON_TTS_USERNAME=
       #- WATSON_TTS_PASSWORD=
-      #If your account is associated with an apikey uncomment WATSON_TTS_APIKEY and WATSON_TTS_TOKEN_SERVICE_PROVIDER_URL and fill apikey accordingly
-      #- WATSON_TTS_APIKEY=
-      #- WATSON_TTS_TOKEN_SERVICE_PROVIDER_URL=https://iam.bluemix.net/identity/token
-      - WATSON_TTS_URL=
       - WATSON_TTS_VOICE=en-US_MichaelVoice
 
       # Uncomment the following three lines to enable call recording

--- a/kubernetes/single-tenant/deploy.yaml
+++ b/kubernetes/single-tenant/deploy.yaml
@@ -50,8 +50,6 @@ spec:
               key: WATSON_STT_APIKEY
         - name: WATSON_STT_URL
           value: https://stream.watsonplatform.net/speech-to-text/api
-        - name: WATSON_STT_TOKEN_SERVICE_PROVIDER_URL
-          value: https://iam.bluemix.net/identity/token
         - name: WATSON_TTS_APIKEY
           valueFrom:
             secretKeyRef:
@@ -60,10 +58,7 @@ spec:
         - name: WATSON_TTS_VOICE
           value: en-US_MichaelVoice
         - name: WATSON_TTS_URL
-          value: https://stream.watsonplatform.net/text-to-speech/api
-        - name: WATSON_TTS_TOKEN_SERVICE_PROVIDER_URL
-          value: https://iam.bluemix.net/identity/token
-          
+          value: https://stream.watsonplatform.net/text-to-speech/api          
         # - name: SSL_CLIENT_CA_CERTIFICATE_FILE
         #   value: "/sslConf/clientCaCertFile"
         
@@ -137,8 +132,6 @@ spec:
             secretKeyRef:
               name: secret-creds
               key: WATSON_CONVERSATION_APIKEY
-        - name: WATSON_CONVERSATION_TOKEN_SERVICE_PROVIDER_URL
-          value: https://iam.bluemix.net/identity/token
         - name: ENABLE_AUDIT_MESSAGES
           value: 'true'
         - name: ENABLE_TRANSCRIPTION_AUDIT_MESSAGES

--- a/voice-agent-tester/kubernetes/sample-deploy.json
+++ b/voice-agent-tester/kubernetes/sample-deploy.json
@@ -81,10 +81,6 @@
 								"value": "8080"
 							},
 							{
-								"name": "WATSON_STT_TOKEN_SERVICE_PROVIDER_URL",
-								"value": "https://iam.bluemix.net/identity/token"
-							},
-							{
 								"name": "WATSON_STT_APIKEY",
 								"valueFrom": {
 									"secretKeyRef": {
@@ -96,10 +92,6 @@
 							{
 								"name": "WATSON_STT_URL",
 								"value": "https://gateway-wdc.watsonplatform.net/speech-to-text/api"
-							},
-							{
-								"name": "WATSON_TTS_TOKEN_SERVICE_PROVIDER_URL",
-								"value": "https://iam.bluemix.net/identity/token"
 							},
 							{
 								"name": "WATSON_TTS_APIKEY",


### PR DESCRIPTION
The samples use the iam.bluemix.net endpoint for IAM Authentication, but on newer release we use
iam.cloud.ibm.com as the endpoint by default.

Contributes to https://github.com/WASdev/sample.voice.gateway/issues/205